### PR TITLE
kukui,corsola,asurada,cherry: disable afbc on mediatek devices

### DIFF
--- a/systems/chromebook_asurada/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_asurada/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,0 +1,3 @@
+# disable afbc in mesa until it is fixed from the kernel side
+# see: https://github.com/velvet-os/imagebuilder/issues/314
+PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_cherry/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_cherry/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,0 +1,3 @@
+# disable afbc in mesa until it is fixed from the kernel side
+# see: https://github.com/velvet-os/imagebuilder/issues/314
+PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_corsola/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_corsola/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,0 +1,3 @@
+# disable afbc in mesa until it is fixed from the kernel side
+# see: https://github.com/velvet-os/imagebuilder/issues/314
+PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_kukui/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_kukui/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,0 +1,3 @@
+# disable afbc in mesa until it is fixed from the kernel side
+# see: https://github.com/velvet-os/imagebuilder/issues/314
+PAN_MESA_DEBUG=noafbc


### PR DESCRIPTION
this is a temporary workaround for the broken afbc on mediatek drm to avoid trouble due to it - see
https://github.com/velvet-os/imagebuilder/issues/314 for more information ... a fix on kernel side is on its way and this can be removed again once it is ready and made its way into the corresponding kernels

oak should not be affected as i think afbc (arm framebuffer compression) is used only between the gpu and drm and there is no useable gpu driver for the mt8173 yet ...