### PR TITLE
multiple: adjust urls to the new home in the velvet-os org

### DIFF
--- a/archive/chromebook_octopus/readme.md
+++ b/archive/chromebook_octopus/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211204-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/211204-02
 
 ## tested systems - working
 

--- a/archive/chromebook_spring/readme.md
+++ b/archive/chromebook_spring/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210726-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210612-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210726-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210612-01
 
 ## tested systems - working
 

--- a/archive/odroid_mc1/readme.md
+++ b/archive/odroid_mc1/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210803-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210508-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210803-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210508-01
 
 ## tested systems - working
 

--- a/archive/odroid_mc1/todo.txt
+++ b/archive/odroid_mc1/todo.txt
@@ -1,7 +1,7 @@
 - find out why the performance is about 20% lower with mainline than with the odroid v5.4 tree (seen with vcvrack)
   - the cpu opp table entries look a bit strange on mainline: the 1.8ghz entry for instance has a lower voltage as the 1.7ghz entry
   - maybe this is the reason for bootup messages like: cpu cpu4: EM: OPP:1700000 is inefficient
-- maybe give the open source panfrost gpu driver a try - see: https://github.com/hexdump0815/imagebuilder/issues/27#issuecomment-1178779950
+- maybe give the open source panfrost gpu driver a try - see: https://github.com/velvet-os/imagebuilder/issues/27#issuecomment-1178779950
   - see also:
     - https://gitlab.com/postmarketOS/pmaports/-/blob/master/device/testing/linux-postmarketos-exynos5/0037-soc-samsung-pm_domains-Bring-back-old-driver-impleme.patch
     - https://oftc.irclog.whitequark.org/panfrost/2022-06-26#31046193

--- a/archive/raspberry_pi_3/readme.md
+++ b/archive/raspberry_pi_3/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210808-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210808-02
 
 ## tested systems - working
 

--- a/archive/rockchip_rk3288/readme.md
+++ b/archive/rockchip_rk3288/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210806-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210806-01
 
 ## tested systems - working
 

--- a/archive/tablet_amazon_karnak/readme.md
+++ b/archive/tablet_amazon_karnak/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220220-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/220220-02
 
 ## tested systems - working
 

--- a/archive/tablet_asus_grouper_tilapia/readme.md
+++ b/archive/tablet_asus_grouper_tilapia/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211230-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/211230-02
 
 ## tested systems - working
 

--- a/readme.md
+++ b/readme.md
@@ -6,41 +6,41 @@
 
 ## System specific information and images :
 
-- banana pi m1 and allwinner h3 tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/allwinner_h3/readme.md
-- allwinner h6 devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/allwinner_h6/readme.md
-- allwinner h616 devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/allwinner_h616/readme.md (wip)
-- amlogic gx (gxbb=s905, gxl=s905x/s905w, gxm=s912, g12a=s905x2, g12b=s922x and sm1=s905x3) devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/amlogic_gx/readme.md
-- amlogic m8 (s802, s805 and s812) devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/amlogic_m8/readme.md
-- intel 64bit atom (z3735f, z3470d, z8300, z8350 etc.) systems (often tablets) with 32bit uefi bios: https://github.com/hexdump0815/imagebuilder/blob/main/systems/atom_x86_with_32bit_uefi/readme.md
-- arm exynos 5250 32bit chromebooks snow: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_snow/readme.md
-- arm exynos 5420/5800 32bit chromebooks peach: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_peach/readme.md
-- arm tegra k1 32bit chromebooks nyan: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_nyan/readme.md
-- arm rockchip rk3288 32bit chromebooks veyron: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_veyron/readme.md
-- arm rockchip rk3399 64bit chromebooks gru: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_gru/readme.md
-- arm mediatek mt8173 64bit chromebooks oak: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_oak/readme.md
-- arm mediatek mt8183 64bit chromebooks kukui: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_kukui/readme.md
-- arm mediatek mt8186 64bit chromebooks corsola: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_corsola/readme.md (wip)
-- arm mediatek mt8192 64bit chromebooks asurada: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_asurada/readme.md (wip)
-- arm mediatek mt8195 64bit chromebooks cherry: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_cherry/readme.md (wip)
-- arm qualcom 7c gen1 and gen2 sc7180 64bit chromebooks trogdor: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_trogdor/readme.md
-- intel chromebooks with legacy/mbr booting firmware and generic intel systems with mbr booting bios: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_x86_mbr/readme.md
-- intel chromebooks with uefi firmware and generic intel systems with uefi bios: https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_x86_uefi/readme.md
-- odroid u3 (u3, u2, x2, x) devices: https://github.com/hexdump0815/imagebuilder/blob/main/systems/odroid_u3/readme.md
-- orbsmart s92, beelink r89 and similar rockchip rk3288 tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/orbsmart_s92_beelink_r89/readme.md
-- raspberry pi 4: https://github.com/hexdump0815/imagebuilder/blob/main/systems/raspberry_pi_4/readme.md
-- rockchip rk33xx (rk3318, rk3328, rk3399) devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/rockchip_rk33xx/readme.md
-- rockchip rk356x (rk3566 and rk3568) devices and tv boxes: https://github.com/hexdump0815/imagebuilder/blob/main/systems/rockchip_rk356x/readme.md (wip)
-- rockchip rk3588 devices: https://github.com/hexdump0815/imagebuilder/blob/main/systems/rockchip_rk3588/readme.md (wip)
-- rockchip rk3566 console powkiddy x55 : https://github.com/hexdump0815/imagebuilder/blob/main/systems/console_x55/readme.md
-- rockchip rk3399 console anbernic rg552 : https://github.com/hexdump0815/imagebuilder/blob/main/systems/console_rg552/readme.md
-- snapdragon sdm835 msm8998 windows on arm devices: https://github.com/hexdump0815/imagebuilder/blob/main/systems/snapdragon_835/readme.md (wip)
-- snapdragon 7c gen1 and gen2 sc7180 windows on arm devices: https://github.com/hexdump0815/imagebuilder/blob/main/systems/snapdragon_7c_woa/readme.md (wip)
-- starfive visionfive 2 risc v sbc: https://github.com/hexdump0815/imagebuilder/blob/main/systems/starfive_visionfive2/readme.md (wip)
-- samsung galaxy tab a 9.7 gt510 msm8916 tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_samsung_gt510/readme.md (wip)
-- motorola moto g4 play msm8916 phones: https://github.com/hexdump0815/imagebuilder/blob/main/systems/phone_motorola_harpia/readme.md (wip)
-- samsung galaxy a52 and a72 sm7125 phones: https://github.com/hexdump0815/imagebuilder/blob/main/systems/phone_samsung_a72q/readme.md (wip)
-- amazon ford tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_amazon_ford/readme.md (legacy, on hold)
-- amazon austin tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_amazon_austin/readme.md (legacy, on hold)
-- amazon giza tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_amazon_giza/readme.md (legacy, on hold)
-- amazon douglas tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_amazon_douglas/readme.md (legacy, on hold)
-- amazon suez tablets: https://github.com/hexdump0815/imagebuilder/blob/main/systems/tablet_amazon_suez/readme.md (legacy, on hold)
+- banana pi m1 and allwinner h3 tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/allwinner_h3/readme.md
+- allwinner h6 devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/allwinner_h6/readme.md
+- allwinner h616 devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/allwinner_h616/readme.md (wip)
+- amlogic gx (gxbb=s905, gxl=s905x/s905w, gxm=s912, g12a=s905x2, g12b=s922x and sm1=s905x3) devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/amlogic_gx/readme.md
+- amlogic m8 (s802, s805 and s812) devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/amlogic_m8/readme.md
+- intel 64bit atom (z3735f, z3470d, z8300, z8350 etc.) systems (often tablets) with 32bit uefi bios: https://github.com/velvet-os/imagebuilder/blob/main/systems/atom_x86_with_32bit_uefi/readme.md
+- arm exynos 5250 32bit chromebooks snow: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_snow/readme.md
+- arm exynos 5420/5800 32bit chromebooks peach: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_peach/readme.md
+- arm tegra k1 32bit chromebooks nyan: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_nyan/readme.md
+- arm rockchip rk3288 32bit chromebooks veyron: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_veyron/readme.md
+- arm rockchip rk3399 64bit chromebooks gru: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_gru/readme.md
+- arm mediatek mt8173 64bit chromebooks oak: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_oak/readme.md
+- arm mediatek mt8183 64bit chromebooks kukui: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_kukui/readme.md
+- arm mediatek mt8186 64bit chromebooks corsola: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_corsola/readme.md (wip)
+- arm mediatek mt8192 64bit chromebooks asurada: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_asurada/readme.md (wip)
+- arm mediatek mt8195 64bit chromebooks cherry: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_cherry/readme.md (wip)
+- arm qualcom 7c gen1 and gen2 sc7180 64bit chromebooks trogdor: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_trogdor/readme.md
+- intel chromebooks with legacy/mbr booting firmware and generic intel systems with mbr booting bios: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_x86_mbr/readme.md
+- intel chromebooks with uefi firmware and generic intel systems with uefi bios: https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_x86_uefi/readme.md
+- odroid u3 (u3, u2, x2, x) devices: https://github.com/velvet-os/imagebuilder/blob/main/systems/odroid_u3/readme.md
+- orbsmart s92, beelink r89 and similar rockchip rk3288 tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/orbsmart_s92_beelink_r89/readme.md
+- raspberry pi 4: https://github.com/velvet-os/imagebuilder/blob/main/systems/raspberry_pi_4/readme.md
+- rockchip rk33xx (rk3318, rk3328, rk3399) devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/rockchip_rk33xx/readme.md
+- rockchip rk356x (rk3566 and rk3568) devices and tv boxes: https://github.com/velvet-os/imagebuilder/blob/main/systems/rockchip_rk356x/readme.md (wip)
+- rockchip rk3588 devices: https://github.com/velvet-os/imagebuilder/blob/main/systems/rockchip_rk3588/readme.md (wip)
+- rockchip rk3566 console powkiddy x55 : https://github.com/velvet-os/imagebuilder/blob/main/systems/console_x55/readme.md
+- rockchip rk3399 console anbernic rg552 : https://github.com/velvet-os/imagebuilder/blob/main/systems/console_rg552/readme.md
+- snapdragon sdm835 msm8998 windows on arm devices: https://github.com/velvet-os/imagebuilder/blob/main/systems/snapdragon_835/readme.md (wip)
+- snapdragon 7c gen1 and gen2 sc7180 windows on arm devices: https://github.com/velvet-os/imagebuilder/blob/main/systems/snapdragon_7c_woa/readme.md (wip)
+- starfive visionfive 2 risc v sbc: https://github.com/velvet-os/imagebuilder/blob/main/systems/starfive_visionfive2/readme.md (wip)
+- samsung galaxy tab a 9.7 gt510 msm8916 tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_samsung_gt510/readme.md (wip)
+- motorola moto g4 play msm8916 phones: https://github.com/velvet-os/imagebuilder/blob/main/systems/phone_motorola_harpia/readme.md (wip)
+- samsung galaxy a52 and a72 sm7125 phones: https://github.com/velvet-os/imagebuilder/blob/main/systems/phone_samsung_a72q/readme.md (wip)
+- amazon ford tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_amazon_ford/readme.md (legacy, on hold)
+- amazon austin tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_amazon_austin/readme.md (legacy, on hold)
+- amazon giza tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_amazon_giza/readme.md (legacy, on hold)
+- amazon douglas tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_amazon_douglas/readme.md (legacy, on hold)
+- amazon suez tablets: https://github.com/velvet-os/imagebuilder/blob/main/systems/tablet_amazon_suez/readme.md (legacy, on hold)

--- a/systems/allwinner_h3/readme.md
+++ b/systems/allwinner_h3/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231126-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210808-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231126-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210808-01
 
 ## tested systems - working
 

--- a/systems/allwinner_h6/readme.md
+++ b/systems/allwinner_h6/readme.md
@@ -2,11 +2,11 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230930-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230222-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220617-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211230-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210805-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/230930-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230222-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220617-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211230-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210805-03
 
 ## tested systems - working
 

--- a/systems/allwinner_h616/readme.md
+++ b/systems/allwinner_h616/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230910-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230222-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220618-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211204-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/230910-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230222-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/220618-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/211204-03
 
 ## tested systems - working
 

--- a/systems/amlogic_gx/readme.md
+++ b/systems/amlogic_gx/readme.md
@@ -2,11 +2,11 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230920-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230220-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220826-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220618-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210805-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230920-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230220-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/220826-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220618-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210805-01
 
 ## tested systems - working
 

--- a/systems/amlogic_m8/readme.md
+++ b/systems/amlogic_m8/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230910-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230224-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210808-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/200823-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230910-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230224-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/210808-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/200823-01
 
 ## tested systems - working
 

--- a/systems/atom_x86_with_32bit_uefi/readme.md
+++ b/systems/atom_x86_with_32bit_uefi/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230917-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230224-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220912-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210811-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230917-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230224-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/220912-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210811-01
 
 ## tested systems - working
 

--- a/systems/bouffalo_lab_bl808/readme.md
+++ b/systems/bouffalo_lab_bl808/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240525-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240525-01
 
 ## tested systems - working
 

--- a/systems/bpi_f3/readme.md
+++ b/systems/bpi_f3/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240521-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240521-01
 
 ## tested systems - working
 

--- a/systems/chromebook_asurada/readme.md
+++ b/systems/chromebook_asurada/readme.md
@@ -2,13 +2,13 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230109-01 (experimental)
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220710-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
+- https://github.com/velvet-os/imagebuilder/releases/tag/220710-01
 
 ## tested systems - working
 
 - acer chromebook cb514-2h/cb514-2ht - spherion
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/60
+  - see also: https://github.com/velvet-os/imagebuilder/issues/60
 
 ## untested systems
 

--- a/systems/chromebook_cherry/extra-files/usr/share/alsa/ucm2/m8195_r1019_568.readme
+++ b/systems/chromebook_cherry/extra-files/usr/share/alsa/ucm2/m8195_r1019_568.readme
@@ -6,4 +6,4 @@ alsaucm  -c m8195_r1019_5682s set _verb HiFi set _enadev Speaker
 alsaucm  -c m8195_r1019_5682s set _verb HiFi set _enadev "Internal Mic"
 ```
 
-More info on https://github.com/hexdump0815/imagebuilder/issues/61
+More info on https://github.com/velvet-os/imagebuilder/issues/61

--- a/systems/chromebook_cherry/readme.md
+++ b/systems/chromebook_cherry/readme.md
@@ -2,13 +2,13 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230109-01 (experimental)
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220710-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
+- https://github.com/velvet-os/imagebuilder/releases/tag/220710-01
 
 ## tested systems - working
 
 - acer chromebook cp513-2h - tomato
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/61
+  - see also: https://github.com/velvet-os/imagebuilder/issues/61
 
 ## untested systems
 

--- a/systems/chromebook_corsola/readme.md
+++ b/systems/chromebook_corsola/readme.md
@@ -2,13 +2,13 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240112-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230626-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240112-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230626-01
 
 ## tested systems - working
 
-- lenovo ideapad slim 3 (mt8186 version) - [magenton](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/corsola/magneton.md)
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/228
+- lenovo ideapad slim 3 (mt8186 version) - [magenton](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/corsola/magneton.md)
+  - see also: https://github.com/velvet-os/imagebuilder/issues/228
 - asus chromebook cm14 (cm1402c) - tentacool
 
 ## untested systems

--- a/systems/chromebook_gru/readme.md
+++ b/systems/chromebook_gru/readme.md
@@ -2,11 +2,11 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231001-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230220-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220822-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220612-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211120-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231001-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230220-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/220822-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220612-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211120-01
 
 ## tested systems - working
 

--- a/systems/chromebook_kukui/extra-files/usr/share/alsa/ucm2/mt8183_da7219_r.readme
+++ b/systems/chromebook_kukui/extra-files/usr/share/alsa/ucm2/mt8183_da7219_r.readme
@@ -1,3 +1,3 @@
 based on https://chromium.googlesource.com/chromiumos/overlays/board-overlays/+/refs/heads/master/overlay-jacuzzi/chromeos-base/chromeos-bsp-jacuzzi/files/fennel14/audio/ucm-config
 
-see also: https://github.com/hexdump0815/imagebuilder/issues/54
+see also: https://github.com/velvet-os/imagebuilder/issues/54

--- a/systems/chromebook_kukui/readme.md
+++ b/systems/chromebook_kukui/readme.md
@@ -2,39 +2,39 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230917-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230218-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220818-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220606-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220528-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210724-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210321-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230917-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230218-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220818-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220606-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220528-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210724-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/210321-01
 
 ## tested systems - working
 
-- lenovo ideapad duet 10.1 chromebook - [krane](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/kukui/krane.md)
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/53
+- lenovo ideapad duet 10.1 chromebook - [krane](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/kukui/krane.md)
+  - see also: https://github.com/velvet-os/imagebuilder/issues/53
 - acer chromebook spin cp311-3h - juniper
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/52
+  - see also: https://github.com/velvet-os/imagebuilder/issues/52
 - hp chromebook 11a - kappa
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/52
+  - see also: https://github.com/velvet-os/imagebuilder/issues/52
 - lenovo ideapad 3 chromebook 14 inch (mt8183 version) - fennel14
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/49
+  - see also: https://github.com/velvet-os/imagebuilder/issues/49
 - lenovo ideapad flex 3 chromebook (mt8183 version) - fennel
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/58
+  - see also: https://github.com/velvet-os/imagebuilder/issues/58
 - asus chromebook flip cm3 (mt8183 version) - damu
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/62
+  - see also: https://github.com/velvet-os/imagebuilder/issues/62
 - asus chromebook cm3 - kakadu
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/71
+  - see also: https://github.com/velvet-os/imagebuilder/issues/71
 - acer chromebook 314 (cb314-2h/cb314-2ht) - cozmo
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/75
+  - see also: https://github.com/velvet-os/imagebuilder/issues/75
 - acer chromebook 311 - kenzo
-  - see https://github.com/hexdump0815/imagebuilder/issues/141#issuecomment-1663779043
-- lenovo 10e chromebook tablet - [kodama](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/kukui/kodama.md)
-  - see https://github.com/hexdump0815/imagebuilder/issues/202
+  - see https://github.com/velvet-os/imagebuilder/issues/141#issuecomment-1663779043
+- lenovo 10e chromebook tablet - [kodama](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/kukui/kodama.md)
+  - see https://github.com/velvet-os/imagebuilder/issues/202
 - asus chromebook detachable cz1 - katsu
 - hp chromebook 11mk g9 ee - burnet/esche
-  - reported via https://github.com/hexdump0815/imagebuilder/issues/187
+  - reported via https://github.com/velvet-os/imagebuilder/issues/187
 
 ## untested systems
 
@@ -63,7 +63,7 @@
 ## special notes
 
 - most things seem to work more or less (mostly thanks to the kernel patches partially taken from https://github.com/Maccraft123/Cadmium/tree/master/baseboard/kukui/patches)
-- it seems that sometimes kukui devices give a high pitch noise after resuming from suspend (seen with kappa and juniper so far) - a useable workaround is to put the device into suspend and wake it up again, then the noise should be gone - see also: https://github.com/hexdump0815/imagebuilder/issues/65
+- it seems that sometimes kukui devices give a high pitch noise after resuming from suspend (seen with kappa and juniper so far) - a useable workaround is to put the device into suspend and wake it up again, then the noise should be gone - see also: https://github.com/velvet-os/imagebuilder/issues/65
 - juniper: sometimes the touchpad does not seem to work after booting, rebooting usually helps
 - krane, kakadu and katsu: the display rotation will be set properly during the first boot, afterwards it will reboot once automatically and should come up with the display correctly set to landscape mode - so please don't be surprised about the first automatic reboot and be ready with ctrl-u for the second boot :)
 - some log spamming kernel messages have been silenced:

--- a/systems/chromebook_nyan/readme.md
+++ b/systems/chromebook_nyan/readme.md
@@ -2,14 +2,14 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230915-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230218-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220611-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211114-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210724-01 (with legacy images)
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210613-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210321-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/200526-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230915-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230218-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/220611-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211114-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210724-01 (with legacy images)
+- https://github.com/velvet-os/imagebuilder/releases/tag/210613-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210321-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/200526-01
 
 ## tested systems - working
 
@@ -17,7 +17,7 @@
 - acer chromebook 13 c810 - nyan big
 - hp chromebook 14 g3 - nyan blaze
 
-see also https://github.com/hexdump0815/imagebuilder/issues/79 for all above
+see also https://github.com/velvet-os/imagebuilder/issues/79 for all above
 
 ## untested systems
 
@@ -57,7 +57,7 @@ see also https://github.com/hexdump0815/imagebuilder/issues/79 for all above
   - if not the mainline kernel version should be used
   - both image types contain both kernels (the other kernel tar.gz file is located in /boot/extra) and can be converted into each other with a hand full of commands (will add them here soon)
   - to make it useable with both kernels the root filesystems uses ext4 and not btrfs like those images here usually as the btrfs support in the legacy kernel is too old to be really useable
-  - for information about using the legacy kernel with legacy gpu drivers please have a look at https://github.com/hexdump0815/imagebuilder/issues/174
+  - for information about using the legacy kernel with legacy gpu drivers please have a look at https://github.com/velvet-os/imagebuilder/issues/174
 - there are several versions of the nyan big available: 2g/4g ram and hd/full hd display
   - the 4gb/full hd i have is working well
   - the 2gb/hd i have is working well, but the u-boot output is not visible as u-boot does not seem to be able to initialize the display properly (a lot of screen flickering or a black screen) - as a result one has to type the number at the boot prompt blindly at the right time for now :)
@@ -72,7 +72,7 @@ see also https://github.com/hexdump0815/imagebuilder/issues/79 for all above
   - 2: linux-big-fhd - nyan big with the full hd 1920x1080 screen
   - 3: linux-blaze - nyan blaze with the 1366x768 screen (not sure if there is maybe a full hd version of the blaze as well?)
 - the default boot blocks installed for the image are for the 4gb model and the default dtb selected is the lower res nyan-big model - not sure if this combination really exists, but one can easily choose the second option (linux-big-fhd) in the u-boot menu to boot for the full hd model and for all other combinations new bootblocks will have to be written and the extlinux.conf file has to be adjusted anyway
-- some nyan big related issue with some info: https://github.com/hexdump0815/imagebuilder/issues/6
+- some nyan big related issue with some info: https://github.com/velvet-os/imagebuilder/issues/6
 - for more info about xorg gpu support see doc/xorg-and-nouveau.md
 - for more info about the suspend/resume topic see doc/suspend-resume.md
 - the thermal cpu throttling was not working with older kernels and the cpu frequency was limited to 1.7 ghz in /etc/rc.local to avoid automatic shutdown due to overheating in case of constant full load (fixed for v5.18+ kernels)

--- a/systems/chromebook_oak/readme.md
+++ b/systems/chromebook_oak/readme.md
@@ -2,18 +2,18 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230920-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230218-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220819-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220606-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210724-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210509-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210321-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230920-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230218-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/220819-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220606-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210724-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210509-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210321-01
 
 ## tested systems - working
 
 - acer chromebook r13 - elm
-- lenovo chromebook 100e (mt8173 version) - [hana](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/oak/hana-100e-gen2.md)
+- lenovo chromebook 100e (mt8173 version) - [hana](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/oak/hana-100e-gen2.md)
 - lenovo chromebook 300e (mt8173 version) - hana
 - lenovo chromebook n23 - hana
 - asus chromebook c202xa - hana
@@ -43,7 +43,7 @@
 - most things seem to work more or less
 - there is no gpu acceleration as there is no open source driver available for the powervr gpu in the mt8173 soc, mesa software rendering is used instead for opengl etc.
 - suspend/resume status:
-  - with v5.10 it works fine (console and xorg) with https://github.com/hexdump0815/imagebuilder/blob/main/systems/chromebook_oak/extra-files/usr/lib/systemd/system-sleep/mrvl-reload - so all images starting with version 210724-02 should be fine
+  - with v5.10 it works fine (console and xorg) with https://github.com/velvet-os/imagebuilder/blob/main/systems/chromebook_oak/extra-files/usr/lib/systemd/system-sleep/mrvl-reload - so all images starting with version 210724-02 should be fine
   - with v5.11+ it is broken as the display does not come back after resume - see todo
   - with v5.18 it is working again, only display sleep is broken and being worked around by special power management settings in the image
 - when booting from an usb medium the bootup might hang waiting to discover the root device - in such cases it might help to shortly unplug and replug the usb medium the system is booted from

--- a/systems/chromebook_peach/readme.md
+++ b/systems/chromebook_peach/readme.md
@@ -2,18 +2,18 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230924-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230220-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220619-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210725-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210613-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230924-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230220-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/220619-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210725-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210613-01
 
 ## tested systems - working
 
 - samsung chromebook xe503c12 - peach pit
 - samsung chromebook xe503c32 - peach pi
 
-see also https://github.com/hexdump0815/imagebuilder/issues/80 for all above
+see also https://github.com/velvet-os/imagebuilder/issues/80 for all above
 
 ## untested systems
 

--- a/systems/chromebook_peach/todo.txt
+++ b/systems/chromebook_peach/todo.txt
@@ -1,5 +1,5 @@
 - rework sound/ucm to maybe support internal and headset mic too - they are disabled for now
   - the problem seems to be that the kernel cannot open the capture channels (maybe full duplex is not working)
-- maybe give the open source panfrost gpu driver a try - see: https://github.com/hexdump0815/imagebuilder/issues/27#issuecomment-1178779950
+- maybe give the open source panfrost gpu driver a try - see: https://github.com/velvet-os/imagebuilder/issues/27#issuecomment-1178779950
   - see also:
     - https://gitlab.com/postmarketOS/pmaports/-/blob/master/device/testing/linux-postmarketos-exynos5/0037-soc-samsung-pm_domains-Bring-back-old-driver-impleme.patch

--- a/systems/chromebook_snow/readme.md
+++ b/systems/chromebook_snow/readme.md
@@ -2,20 +2,20 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230924-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230220-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220619-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210725-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210613-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210321-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/191230-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230924-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230220-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220619-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210725-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210613-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/210321-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/191230-01
 
 ## tested systems - working
 
 - samsung chromebook xe303c12 rev4 - snow
 - samsung chromebook xe303c12 rev5 - snow
 
-see also https://github.com/hexdump0815/imagebuilder/issues/78 for all above
+see also https://github.com/velvet-os/imagebuilder/issues/78 for all above
 
 ## tested systems - partially working
 
@@ -45,7 +45,7 @@ see also https://github.com/hexdump0815/imagebuilder/issues/78 for all above
 - active support from google for the snow chromebooks (samsung xe303c12) ended beginning of 2019, so they might be around for cheap
 - they are very nice to use with linux: small, light (just a bit above 1kg), battery lasts for 4-6 hours at least
 - it looks like he snow chromebooks from 2014 on are rev5, but i'm not sure at which point in time exactly the switch between rev4 and rev5 is - end of 2012 is definitely rev4 (and the very early ones seem to even be buggy - see below) and early 2013 is rev4 as well
-- please be aware that there seems to be an early batch of snow chromebooks which are not running stable with a mainline kernel, but are running well with a legacy chromeos based kernel - looks like some hardware problem, which was silently fixed in the chromeos kernel but never made it to mainline - this problem has been observed on a snow chromebook from october 2012 and on one from january 2013, so i guess it affects the first ones from end of 2012 and beginning of 2013 - see: https://github.com/hexdump0815/imagebuilder/issues/63
+- please be aware that there seems to be an early batch of snow chromebooks which are not running stable with a mainline kernel, but are running well with a legacy chromeos based kernel - looks like some hardware problem, which was silently fixed in the chromeos kernel but never made it to mainline - this problem has been observed on a snow chromebook from october 2012 and on one from january 2013, so i guess it affects the first ones from end of 2012 and beginning of 2013 - see: https://github.com/velvet-os/imagebuilder/issues/63
 - what does not work with mainline:
   - usb3 might be unreliable, connecting devices through a usb2 hub seems to be a possible workaround in case of problems
   - 3g modem (not tested)

--- a/systems/chromebook_snow/todo.txt
+++ b/systems/chromebook_snow/todo.txt
@@ -15,6 +15,6 @@
   - i tried to improve the ucm setup, but was not able to get anything reliably better - best was working speaker and headphones, but after once switching to headphones and back some ugly distortion came along every few seconds - so i kept the hacked simple setup with only speaker output for now
   - there is a hack in place so that there is at least some working pulseaudio output
   - mic input not working - the problem seems to be that the kernel cannot open the capture channels (maybe full duplex is not working)
-- maybe give the open source panfrost gpu driver a try - see: https://github.com/hexdump0815/imagebuilder/issues/27#issuecomment-1179535653
+- maybe give the open source panfrost gpu driver a try - see: https://github.com/velvet-os/imagebuilder/issues/27#issuecomment-1179535653
   - see also:
     - https://gitlab.com/postmarketOS/pmaports/-/blob/master/device/testing/linux-postmarketos-exynos5/0037-soc-samsung-pm_domains-Bring-back-old-driver-impleme.patch

--- a/systems/chromebook_trogdor/readme.md
+++ b/systems/chromebook_trogdor/readme.md
@@ -2,22 +2,22 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230922-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230501-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230218-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220814-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211120-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230922-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230501-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230218-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/220814-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211120-02
 
 ## tested systems - working
 
-- acer chromebook spin sp513-1h/sp513-1hl - [lazor](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/trogdor/lazor.md)
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/47
+- acer chromebook spin sp513-1h/sp513-1hl - [lazor](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/trogdor/lazor.md)
+  - see also: https://github.com/velvet-os/imagebuilder/issues/47
 - hp chromebook x2 - coachz
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/44
-- lenovo chromeboot duet 5 - [homestar](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/trogdor/homestar.md)
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/68
-- lenovo chromeboot duet 3 - [wormdingler](https://github.com/hexdump0815/imagebuilder-doc/blob/main/chromebooks/systems/trogdor/wormdingler.md)
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/182
+  - see also: https://github.com/velvet-os/imagebuilder/issues/44
+- lenovo chromeboot duet 5 - [homestar](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/trogdor/homestar.md)
+  - see also: https://github.com/velvet-os/imagebuilder/issues/68
+- lenovo chromeboot duet 3 - [wormdingler](https://github.com/velvet-os/velvet-os.github.io/blob/main/chromebooks/systems/trogdor/wormdingler.md)
+  - see also: https://github.com/velvet-os/imagebuilder/issues/182
 
 ## untested systems
 

--- a/systems/chromebook_veyron/readme.md
+++ b/systems/chromebook_veyron/readme.md
@@ -2,14 +2,14 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231001-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230218-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220820-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220611-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210731-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210613-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210321-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/200526-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231001-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230218-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/220820-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220611-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210731-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210613-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/210321-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/200526-01
 
 ## tested systems - working
 
@@ -17,14 +17,14 @@
 - medion chromebook s2015 - mighty
 - asus chromebook c201 - speedy
 - asus chromebook c100 - minnie
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/16
+  - see also: https://github.com/velvet-os/imagebuilder/issues/16
 - hisense chromebook 11 - jerry
 - edugear chromebook m series - mighty
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/110
+  - see also: https://github.com/velvet-os/imagebuilder/issues/110
 - asus chromebit cs10 - mickey
-  - u-boot not working yet: https://github.com/hexdump0815/imagebuilder/issues/130#issuecomment-1454334195
+  - u-boot not working yet: https://github.com/velvet-os/imagebuilder/issues/130#issuecomment-1454334195
 
-see also https://github.com/hexdump0815/imagebuilder/issues/81 for all above
+see also https://github.com/velvet-os/imagebuilder/issues/81 for all above
 
 ## untested systems
 

--- a/systems/chromebook_x86_mbr/readme.md
+++ b/systems/chromebook_x86_mbr/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231002-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230222-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220912-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210724-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/231002-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230222-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/220912-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210724-04
 
 ## tested systems - working
 

--- a/systems/chromebook_x86_uefi/doc/apollo-and-gemini-lake-chromebooks.md
+++ b/systems/chromebook_x86_uefi/doc/apollo-and-gemini-lake-chromebooks.md
@@ -231,7 +231,7 @@ apt-mark hold firmware-intel-sound
 seems to default to headphones initially by default
 - it might require a special kernel build to work - see
   https://github.com/hexdump0815/linux-mainline-x86-64-kernel/releases and
-https://github.com/hexdump0815/imagebuilder/blob/main/doc/chromebooks/kernel/installing-a-newer-kernel.md
+https://github.com/velvet-os/imagebuilder/blob/main/doc/chromebooks/kernel/installing-a-newer-kernel.md
 
 ### trixie images from may 2025 or later
 

--- a/systems/chromebook_x86_uefi/doc/skylake-chromebooks.md
+++ b/systems/chromebook_x86_uefi/doc/skylake-chromebooks.md
@@ -33,7 +33,7 @@ update-grub
 ```
 some firmware and audio configuration files have to be installed which can be
 obtained from here:
-https://github.com/hexdump0815/imagebuilder-firmware/raw/main/chell-audio.tar.gz
+https://github.com/velvet-os/imagebuilder-firmware/raw/main/chell-audio.tar.gz
 via:
 ```
 cd /
@@ -57,9 +57,9 @@ most probably is best to simply use one of those small usb audio adapters.
 
 please keep in mind to build a new v5.10.x kernel from time to time to get
 the latest security updates. some notes about this can be found here:
-https://github.com/hexdump0815/imagebuilder/blob/main/doc/chromebooks/kernel/building-own-kernels.md
+https://github.com/velvet-os/imagebuilder/blob/main/doc/chromebooks/kernel/building-own-kernels.md
 and here:
-https://github.com/hexdump0815/imagebuilder/blob/main/doc/chromebooks/kernel/installing-a-newer-kernel.md
+https://github.com/velvet-os/imagebuilder/blob/main/doc/chromebooks/kernel/installing-a-newer-kernel.md
 
 ### trixie images from may 2025 or later
 

--- a/systems/chromebook_x86_uefi/readme.md
+++ b/systems/chromebook_x86_uefi/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231002-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230222-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220906-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210724-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/231002-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230222-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/220906-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210724-04
 
 ## tested systems - working
 

--- a/systems/console_rg552/readme.md
+++ b/systems/console_rg552/readme.md
@@ -7,7 +7,7 @@
 ## tested systems - working
 
 - anberic rg552
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/276
+  - see also: https://github.com/velvet-os/imagebuilder/issues/276
 
 _likely won't work on other devices_
 

--- a/systems/console_x55/readme.md
+++ b/systems/console_x55/readme.md
@@ -7,7 +7,7 @@
 ## tested systems - working
 
 - powkiddy x55
-  - see also: https://github.com/hexdump0815/imagebuilder/issues/266
+  - see also: https://github.com/velvet-os/imagebuilder/issues/266
 
 _likely won't work on other devices_
 

--- a/systems/milk_v_duo/readme.md
+++ b/systems/milk_v_duo/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240526-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240526-01
 
 ## tested systems - working
 

--- a/systems/odroid_u3/readme.md
+++ b/systems/odroid_u3/readme.md
@@ -2,12 +2,12 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230915-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230224-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220824-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220612-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210803-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210508-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230915-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230224-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/220824-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220612-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/210803-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210508-01
 
 ## tested systems - working
 
@@ -50,5 +50,5 @@
 - for a working edid file for a 1280x720 screen resolution see https://forum.odroid.com/viewtopic.php?p=329241&sid=7a49d9e1a9c91ee32c46bf6dc64c5b47#p329241
 - for a patched libc to make widevine working see https://forum.odroid.com/viewtopic.php?p=329192&sid=7a49d9e1a9c91ee32c46bf6dc64c5b47#p329192
 - for a precompiled kodi with hw accel to use with this image please see https://forum.odroid.com/viewtopic.php?p=329945&sid=7a49d9e1a9c91ee32c46bf6dc64c5b47#p329945
-- some notes on running the image on the odroid u: https://github.com/hexdump0815/imagebuilder/issues/39
-- some infos about booting these images from emmc can be found here: https://github.com/hexdump0815/imagebuilder/issues/1 and here: https://github.com/hexdump0815/u-boot-misc/blob/master/readme.exy#L35-L49
+- some notes on running the image on the odroid u: https://github.com/velvet-os/imagebuilder/issues/39
+- some infos about booting these images from emmc can be found here: https://github.com/velvet-os/imagebuilder/issues/1 and here: https://github.com/hexdump0815/u-boot-misc/blob/master/readme.exy#L35-L49

--- a/systems/orbsmart_s92_beelink_r89/readme.md
+++ b/systems/orbsmart_s92_beelink_r89/readme.md
@@ -2,12 +2,12 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231002-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230222-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220825-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220612-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210803-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210509-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/231002-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/230222-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/220825-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220612-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/210803-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/210509-02
 
 ## tested systems - working
 
@@ -30,7 +30,7 @@
 
 the boot loader of those tv boxes seems to be encrypted and locked and thus cannot be easily replaced, but there is a properly signed etc. boot block which can get regular linux kernel booting - i have adjusted some scripts around this to create a boot block in the proper format from a mainline linux kernel, dtb and initrd at:
 
-- https://github.com/hexdump0815/imagebuilder/tree/main/systems/orbsmart_s92_beelink_r89/extra-files/boot/r89-boot
+- https://github.com/velvet-os/imagebuilder/tree/main/systems/orbsmart_s92_beelink_r89/extra-files/boot/r89-boot
 
 ## mesa build notes
 

--- a/systems/phone_motorola_harpia/readme.md
+++ b/systems/phone_motorola_harpia/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231111-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211231-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/231111-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/211231-02
 
 ## tested systems - working
 

--- a/systems/phone_samsung_a72q/extra-files/lib/firmware/qcom/sm7125/readme.txt
+++ b/systems/phone_samsung_a72q/extra-files/lib/firmware/qcom/sm7125/readme.txt
@@ -1,3 +1,3 @@
 please put the firmware files from the windows installation here - for more
 info see:
-https://github.com/hexdump0815/imagebuilder/blob/main/systems/phone_samsung_a72q/doc/required-firmware.md
+https://github.com/velvet-os/imagebuilder/blob/main/systems/phone_samsung_a72q/doc/required-firmware.md

--- a/systems/phone_samsung_a72q/get-files.sh
+++ b/systems/phone_samsung_a72q/get-files.sh
@@ -6,4 +6,4 @@ rm -f ${DOWNLOAD_DIR}/kernel-phone_samsung_a72q-${2}.tar.gz
 wget -v https://github.com/hexdump0815/linux-mainline-qcom-kernel/releases/download/${samsung_a72q_release_version}/${samsung_a72q_release_version}.tar.gz -O ${DOWNLOAD_DIR}/kernel-phone_samsung_a72q-${2}.tar.gz
 
 # get the firmware and related files to get wifi and other things working - maybe an option for the future ...
-#wget -v https://github.com/hexdump0815/imagebuilder-firmware/raw/main/phone-samsung-a72q-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/phone-samsung-a72q-firmware.tar.gz
+#wget -v https://github.com/velvet-os/imagebuilder-firmware/raw/main/phone-samsung-a72q-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/phone-samsung-a72q-firmware.tar.gz

--- a/systems/phone_samsung_a72q/readme.md
+++ b/systems/phone_samsung_a72q/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231126-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230929-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231126-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230929-01
 
 ## tested systems - working
 

--- a/systems/raspberry_pi_4/readme.md
+++ b/systems/raspberry_pi_4/readme.md
@@ -2,9 +2,9 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231002-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230224-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210808-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/231002-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/230224-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210808-03
 
 ## tested systems - working
 

--- a/systems/rockchip_rk33xx/readme.md
+++ b/systems/rockchip_rk33xx/readme.md
@@ -2,12 +2,12 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230930-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230220-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220821-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220616-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/210805-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/200702-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230930-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230220-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/220821-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/220616-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/210805-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/200702-01
 
 ## tested systems - working
 

--- a/systems/rockchip_rk356x/readme.md
+++ b/systems/rockchip_rk356x/readme.md
@@ -2,9 +2,9 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231002-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230224-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230122-01 (experimental first image)
+- https://github.com/velvet-os/imagebuilder/releases/tag/231002-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/230224-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230122-01 (experimental first image)
 
 ## tested systems - working
 

--- a/systems/rockchip_rk3588/readme.md
+++ b/systems/rockchip_rk3588/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230321-01 (radxa rock 5b)
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230122-02 (orange pi 5)
+- https://github.com/velvet-os/imagebuilder/releases/tag/230321-01 (radxa rock 5b)
+- https://github.com/velvet-os/imagebuilder/releases/tag/230122-02 (orange pi 5)
 
 ## tested systems - working
 

--- a/systems/snapdragon_7c_woa/extra-files/lib/firmware/qcom/sc7180/readme.txt
+++ b/systems/snapdragon_7c_woa/extra-files/lib/firmware/qcom/sc7180/readme.txt
@@ -1,3 +1,3 @@
 please put the firmware files from the windows installation here - for more
 info see:
-https://github.com/hexdump0815/imagebuilder/blob/main/systems/snapdragon_7c_woa/doc/required-firmware.md
+https://github.com/velvet-os/imagebuilder/blob/main/systems/snapdragon_7c_woa/doc/required-firmware.md

--- a/systems/snapdragon_7c_woa/readme.md
+++ b/systems/snapdragon_7c_woa/readme.md
@@ -2,17 +2,17 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240107-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230308-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230305-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/221101-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240107-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230308-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230305-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/221101-01
 
 ## tested systems - working
 
 - samsung galaxy book go (snapdragon 7c gen2)
 - acer aspire 1 a114-61 (snapdragon 7c)
 
-see also https://github.com/hexdump0815/imagebuilder/issues/136 for all above
+see also https://github.com/velvet-os/imagebuilder/issues/136 for all above
 
 ## untested systems
 

--- a/systems/snapdragon_835/readme.md
+++ b/systems/snapdragon_835/readme.md
@@ -2,10 +2,10 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240112-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230322-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/221101-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211204-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240112-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230322-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/221101-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211204-01
 
 ## tested systems - working
 

--- a/systems/starfive_visionfive2/readme.md
+++ b/systems/starfive_visionfive2/readme.md
@@ -2,9 +2,9 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/240519-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230321-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/230115-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/240519-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/230321-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/230115-01
 
 ## tested systems - working
 

--- a/systems/tablet_amazon_austin/get-files.sh
+++ b/systems/tablet_amazon_austin/get-files.sh
@@ -24,4 +24,4 @@ mkdir -p ${DOWNLOAD_DIR}/postinstall-${1}
 wget -v https://github.com/hexdump0815/msm-fb-refresher/releases/download/${fb_refresher_version}/opt-msm-fb-refresher-${3}-armv7l.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/opt-msm-fb-refresher-${3}-armv7l.tar.gz
 
 # get the firmware and related files to get wifi working
-wget -v https://github.com/hexdump0815/imagebuilder-firmware/raw/main/tablet_amazon_austin-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_austin-firmware.tar.gz
+wget -v https://github.com/velvet-os/imagebuilder-firmware/raw/main/tablet_amazon_austin-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_austin-firmware.tar.gz

--- a/systems/tablet_amazon_austin/readme.md
+++ b/systems/tablet_amazon_austin/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231113-02
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211101-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/231113-02
+- https://github.com/velvet-os/imagebuilder/releases/tag/211101-02
 
 ## tested systems - working
 

--- a/systems/tablet_amazon_douglas/get-files.sh
+++ b/systems/tablet_amazon_douglas/get-files.sh
@@ -18,4 +18,4 @@ wget -v https://github.com/hexdump0815/pmaports-amazon/releases/download/${amazo
 # get the firmware and related files to get wifi working
 rm -rf ${DOWNLOAD_DIR}/postinstall-${1}
 mkdir -p ${DOWNLOAD_DIR}/postinstall-${1}
-wget -v https://github.com/hexdump0815/imagebuilder-firmware/raw/main/tablet_amazon_douglas-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_douglas-firmware.tar.gz
+wget -v https://github.com/velvet-os/imagebuilder-firmware/raw/main/tablet_amazon_douglas-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_douglas-firmware.tar.gz

--- a/systems/tablet_amazon_douglas/readme.md
+++ b/systems/tablet_amazon_douglas/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231113-04
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211101-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/231113-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/211101-03
 
 ## tested systems - working
 

--- a/systems/tablet_amazon_ford/get-files.sh
+++ b/systems/tablet_amazon_ford/get-files.sh
@@ -21,4 +21,4 @@ mkdir -p ${DOWNLOAD_DIR}/postinstall-${1}
 wget -v https://github.com/hexdump0815/msm-fb-refresher/releases/download/${fb_refresher_version}/opt-msm-fb-refresher-${3}-armv7l.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/opt-msm-fb-refresher-${3}-armv7l.tar.gz
 
 # get the firmware and related files to get wifi working
-wget -v https://github.com/hexdump0815/imagebuilder-firmware/raw/main/tablet_amazon_ford-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_ford-firmware.tar.gz
+wget -v https://github.com/velvet-os/imagebuilder-firmware/raw/main/tablet_amazon_ford-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_ford-firmware.tar.gz

--- a/systems/tablet_amazon_ford/readme.md
+++ b/systems/tablet_amazon_ford/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231113-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211101-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231113-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211101-01
 
 ## tested systems - working
 

--- a/systems/tablet_amazon_giza/get-files.sh
+++ b/systems/tablet_amazon_giza/get-files.sh
@@ -18,4 +18,4 @@ wget -v https://github.com/hexdump0815/pmaports-amazon/releases/download/${amazo
 # get the firmware and related files to get wifi working - gize seems to work fine with the douglas firmware
 rm -rf ${DOWNLOAD_DIR}/postinstall-${1}
 mkdir -p ${DOWNLOAD_DIR}/postinstall-${1}
-wget -v https://github.com/hexdump0815/imagebuilder-firmware/raw/main/tablet_amazon_douglas-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_douglas-firmware.tar.gz
+wget -v https://github.com/velvet-os/imagebuilder-firmware/raw/main/tablet_amazon_douglas-firmware.tar.gz -O ${DOWNLOAD_DIR}/postinstall-${1}/tablet_amazon_douglas-firmware.tar.gz

--- a/systems/tablet_amazon_giza/readme.md
+++ b/systems/tablet_amazon_giza/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231113-03
-- https://github.com/hexdump0815/imagebuilder/releases/tag/220220-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231113-03
+- https://github.com/velvet-os/imagebuilder/releases/tag/220220-01
 
 ## tested systems - working
 

--- a/systems/tablet_amazon_suez/readme.md
+++ b/systems/tablet_amazon_suez/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231113-05
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211101-04
+- https://github.com/velvet-os/imagebuilder/releases/tag/231113-05
+- https://github.com/velvet-os/imagebuilder/releases/tag/211101-04
 
 ## tested systems - working
 

--- a/systems/tablet_samsung_gt510/readme.md
+++ b/systems/tablet_samsung_gt510/readme.md
@@ -2,8 +2,8 @@
 
 ## bootable sd card images
 
-- https://github.com/hexdump0815/imagebuilder/releases/tag/231111-01
-- https://github.com/hexdump0815/imagebuilder/releases/tag/211231-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/231111-01
+- https://github.com/velvet-os/imagebuilder/releases/tag/211231-01
 
 ## tested systems - working
 

--- a/todo.txt
+++ b/todo.txt
@@ -3,15 +3,15 @@
 - add more doc info to the top level readme (initial setup, scripts in /scripts dir etc.)
 - maybe add apple m1 support when asahi linux progressed far enough
 - maybe create some useable qemu images too
-- check potential problem with the systemd-gpt-auto-generator - see: https://github.com/hexdump0815/imagebuilder/issues/43#issuecomment-1116133516
-- maybe provide kernel headers as well as part of the kernel tar.gz files - see: https://github.com/hexdump0815/imagebuilder/issues/31#issuecomment-1111972167
+- check potential problem with the systemd-gpt-auto-generator - see: https://github.com/velvet-os/imagebuilder/issues/43#issuecomment-1116133516
+- maybe provide kernel headers as well as part of the kernel tar.gz files - see: https://github.com/velvet-os/imagebuilder/issues/31#issuecomment-1111972167
 - investigate if its possible to replace the first boot image on newer chromebooks - should be possible and means most probably just to find the proper format, tools to create it and to replace it in the boot flash area
   - this looks way more complicated than initially thought:
     - deleting the vbgfx.bin, font.bin and selected locale_xy.bin via cbfstool results in an ugly white screen with some half corrupted text
     - unpacking the .bin files with some hacked together python script gives a lot of bmp files with graphics and text fragments on white background from which the screens are assembled
       - the cbfs .bin archive format used is defined here: https://github.com/coreboot/coreboot/blob/master/util/archive/archive.h
     - as a result the white background seems to be set in the bootloader and the maximum somewhat easily possible might be a nearly white initial boot screen by replacing all visible bmp fragments with completely white ones of the same size
-- recheck the partition flags and check the loadpin kernel option - see: https://github.com/hexdump0815/imagebuilder/issues/43#issuecomment-1155224159
+- recheck the partition flags and check the loadpin kernel option - see: https://github.com/velvet-os/imagebuilder/issues/43#issuecomment-1155224159
 - rewrite the emmc luks install document to be more clear and create different sections for the different setups (chromebook, efi, mbr, u-boot etc.)
 
 luk


### PR DESCRIPTION
this is essentially a run of
find * -type f | xargs sed -i 's,hexdump0815/imagebuilder,velvet-os/imagebuilder,g' find * -type f | xargs sed -i 's,velvet-os/imagebuilder-doc,velvet-os/velvet-os.github.io,g' across all files ...