### PR TITLE
files: rc.local remove no longer needed workaround

### DIFF
--- a/files/extra-files/etc/rc.local
+++ b/files/extra-files/etc/rc.local
@@ -98,9 +98,3 @@ fi
 #    done
 #  fi
 #fi
-
-# kernels from at least v6.2 to v6.6 seem to only enable zswap after an extra
-# swapon in case the kernel default is to have zswap disabled - so lets do a
-# quick swapoff and swapon cycle to make sure the zswap really gets enabled
-#swapoff -a
-#swapon -a


### PR DESCRIPTION
the commented out swapoff and swapon was added as a potential workaround for problems in some kernel versions - with any recent or updated kernel this should no longer be required, so lets remove it ...