### PR TITLE
kukui,corsola,asurada,cherry: disable some opengl for gtk on panfrost

### DIFF
--- a/systems/chromebook_asurada/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_asurada/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,0 +1,5 @@
+# disable some opengl extensions for gtk rendering as there
+# will be problems with the panfrost gpu drivers otherwise
+# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
+# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
+GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_cherry/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_cherry/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,0 +1,5 @@
+# disable some opengl extensions for gtk rendering as there
+# will be problems with the panfrost gpu drivers otherwise
+# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
+# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
+GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_corsola/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_corsola/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,0 +1,5 @@
+# disable some opengl extensions for gtk rendering as there
+# will be problems with the panfrost gpu drivers otherwise
+# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
+# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
+GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_kukui/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_kukui/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,0 +1,5 @@
+# disable some opengl extensions for gtk rendering as there
+# will be problems with the panfrost gpu drivers otherwise
+# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
+# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
+GDK_GL_DISABLE=base-instance


### PR DESCRIPTION
disable some opengl extensions for gtk rendering as there will be problems with the panfrost gpu drivers otherwise see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708 and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297

this can be removed again once it is tested to be working well in different setups