### PR TITLE
multiple: add links to the debian trixie testimages

### DIFF
--- a/systems/allwinner_h3/readme.md
+++ b/systems/allwinner_h3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231126-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/210808-01
 

--- a/systems/allwinner_h6/readme.md
+++ b/systems/allwinner_h6/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230930-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/220617-01

--- a/systems/allwinner_h616/readme.md
+++ b/systems/allwinner_h616/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230910-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/220618-02

--- a/systems/amlogic_gx/readme.md
+++ b/systems/amlogic_gx/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230920-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/220826-01

--- a/systems/amlogic_m8/readme.md
+++ b/systems/amlogic_m8/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230910-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-03
 - https://github.com/velvet-os/imagebuilder/releases/tag/210808-04

--- a/systems/atom_x86_with_32bit_uefi/readme.md
+++ b/systems/atom_x86_with_32bit_uefi/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230917-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/220912-02

--- a/systems/bpi_f3/readme.md
+++ b/systems/bpi_f3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-04 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240521-01
 
 ## tested systems - working

--- a/systems/chromebook_corsola/readme.md
+++ b/systems/chromebook_corsola/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240112-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230626-01
 

--- a/systems/chromebook_gru/readme.md
+++ b/systems/chromebook_gru/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231001-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-03
 - https://github.com/velvet-os/imagebuilder/releases/tag/220822-01

--- a/systems/chromebook_kukui/readme.md
+++ b/systems/chromebook_kukui/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230917-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/220818-01

--- a/systems/chromebook_nyan/readme.md
+++ b/systems/chromebook_nyan/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230915-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/220611-01

--- a/systems/chromebook_oak/readme.md
+++ b/systems/chromebook_oak/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230920-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/220819-01

--- a/systems/chromebook_peach/readme.md
+++ b/systems/chromebook_peach/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230924-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/220619-02

--- a/systems/chromebook_snow/readme.md
+++ b/systems/chromebook_snow/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230924-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/220619-01

--- a/systems/chromebook_trogdor/readme.md
+++ b/systems/chromebook_trogdor/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230922-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230501-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-03

--- a/systems/chromebook_veyron/readme.md
+++ b/systems/chromebook_veyron/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231001-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/220820-01

--- a/systems/chromebook_x86_mbr/readme.md
+++ b/systems/chromebook_x86_mbr/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-03
 - https://github.com/velvet-os/imagebuilder/releases/tag/220912-01

--- a/systems/chromebook_x86_uefi/readme.md
+++ b/systems/chromebook_x86_uefi/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/220906-01

--- a/systems/odroid_u3/readme.md
+++ b/systems/odroid_u3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230915-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/220824-01

--- a/systems/orbsmart_s92_beelink_r89/readme.md
+++ b/systems/orbsmart_s92_beelink_r89/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/220825-01

--- a/systems/phone_motorola_harpia/readme.md
+++ b/systems/phone_motorola_harpia/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-05 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231111-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/211231-02
 

--- a/systems/raspberry_pi_4/readme.md
+++ b/systems/raspberry_pi_4/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-03
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/210808-03

--- a/systems/rockchip_rk33xx/readme.md
+++ b/systems/rockchip_rk33xx/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230930-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/220821-01

--- a/systems/rockchip_rk356x/readme.md
+++ b/systems/rockchip_rk356x/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230122-01 (experimental first image)

--- a/systems/snapdragon_7c_woa/readme.md
+++ b/systems/snapdragon_7c_woa/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-08 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240107-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230308-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230305-01

--- a/systems/snapdragon_835/readme.md
+++ b/systems/snapdragon_835/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-08 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240112-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230322-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/221101-01

--- a/systems/starfive_visionfive2/readme.md
+++ b/systems/starfive_visionfive2/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-04 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240519-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230321-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230115-01

--- a/systems/tablet_samsung_gt510/readme.md
+++ b/systems/tablet_samsung_gt510/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-05 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231111-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/211231-01
 


### PR DESCRIPTION
according to own testing and reports the debian trixie testimages can be considered better meanwhile than the often close to two year old bookworm images, so lets link them for all the systems where we have them

those testimages should be really useable and should also update cleanly into the final debian trixie release once it is out, so there is no real reason to not use them