### PR TITLE
multiple: add exp. testimage links for the recently added systems

### DIFF
--- a/systems/aarch64_mbr_uefi/readme.md
+++ b/systems/aarch64_mbr_uefi/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- none yet
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 
 ## tested systems - working
 
@@ -26,4 +26,5 @@
 
 ## special notes
 
-- coming soon
+- the experimental testimage is ment as a starting point for people who want to help bringing support for this system forward, it has missing features and bugs etc. and should not be considered fully daily useable
+- more coming soon

--- a/systems/chromebook_asurada/readme.md
+++ b/systems/chromebook_asurada/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
 - https://github.com/velvet-os/imagebuilder/releases/tag/220710-01
 
@@ -35,6 +36,7 @@
 
 ## special notes
 
+- the experimental testimage is ment as a starting point for people who want to help bringing support for this system forward, it has missing features and bugs etc. and should not be considered fully daily useable
 - this is just some initial draft to support this system without having the actual hardware - in case someone wants to donate the hardware to me, please let me know :)
 - this is still very much wip and untested, things might work or might not work
 - as long as the chromeos kernel is used there is no gpu support

--- a/systems/chromebook_cherry/readme.md
+++ b/systems/chromebook_cherry/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
 - https://github.com/velvet-os/imagebuilder/releases/tag/220710-01
 
@@ -39,6 +40,7 @@
 
 ## special notes
 
+- the experimental testimage is ment as a starting point for people who want to help bringing support for this system forward, it has missing features and bugs etc. and should not be considered fully daily useable
 - this is just some initial draft to support this system without having the actual hardware - in case someone wants to donate the hardware to me, please let me know :)
 - this is still very much wip and untested, things might work or might not work
 - as long as the chromeos kernel is used there is no gpu support

--- a/systems/chromebook_geralt/readme.md
+++ b/systems/chromebook_geralt/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- none yet
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 
 ## tested systems - working
 
@@ -27,6 +27,7 @@
 
 ## special notes
 
+- the experimental testimage is ment as a starting point for people who want to help bringing support for this system forward, it has missing features and bugs etc. and should not be considered fully daily useable
 - this is just some initial draft to support the bringup of this system
 - this is still very much wip and not well tested, things might work or might not work
 - as long as the chromeos kernel is used there is no gpu support

--- a/systems/chromebook_rauru/readme.md
+++ b/systems/chromebook_rauru/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- none yet
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 
 ## tested systems - working
 
@@ -27,6 +27,7 @@
 
 ## special notes
 
+- the experimental testimage is ment as a starting point for people who want to help bringing support for this system forward, it has missing features and bugs etc. and should not be considered fully daily useable
 - this is just some initial draft to support the bringup of this system
 - this is still very much wip and not well tested, things might work or might not work
 - as long as the chromeos kernel is used there is no gpu support


### PR DESCRIPTION
those experimental testimages are ment as a starting point for people who want to help bringing support for those systems forward, they have missing features and bugs etc. and should not be considered fully daily useable