### PR TITLE
Update codename of ASUS_Chromebook_Tablet_CT100

### DIFF
--- a/systems/chromebook_gru/readme.md
+++ b/systems/chromebook_gru/readme.md
@@ -17,7 +17,7 @@
 
 ## untested systems
 
-- asus chromebook tablet ct100 - maybe scarlet too?
+- asus chromebook tablet ct100 - dumo
 
 ## generic mainline linux on arm chromebook notes
 


### PR DESCRIPTION
As per https://wiki.postmarketos.org/wiki/ASUS_Chromebook_Tablet_CT100_(google-dumo), the ASUS Chromebook Tablet CT100 has codename dumo.

I am planning to get this device, fingers crossed